### PR TITLE
Fix get telemetry sample speed, fix telemetry samples blocking io.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titan-academy/track-titan-ibt-telemetry",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "iRacing ibt parser",
   "keywords": [
     "iracing",

--- a/src/telemetry-sample.js
+++ b/src/telemetry-sample.js
@@ -1,39 +1,89 @@
 import Irsdk from './irsdk-constants'
-import R from 'ramda'
 
 const variableHeaders = new WeakMap()
+const parameterMaps = new WeakMap()
+const dataViews = new WeakMap()
 
 export default class TelemetrySample {
   constructor (buff, varHeaders) {
     this._buff = buff
     variableHeaders.set(this, varHeaders)
+    
+    // Create case-insensitive parameter lookup map for O(1) access
+    const paramMap = new Map(varHeaders.map(h => [h.name.toLowerCase(), h]))
+    parameterMaps.set(this, paramMap)
+    
+    // Create DataView for efficient buffer reading
+    const view = new DataView(buff.buffer, buff.byteOffset, buff.byteLength)
+    dataViews.set(this, view)
   }
 
   getParam (sampleVariableName) {
-    const header = variableHeaders.get(this)
-      .find(h => h.name.toLowerCase() === sampleVariableName.toLowerCase())
+    const paramMap = parameterMaps.get(this)
+    const header = paramMap.get(sampleVariableName.toLowerCase())
 
     if (!header) {
       return null
     }
 
     const variable = Irsdk.varType[header.type]
-    const valueBuffer = this._buff.slice(header.offset, header.offset + variable.size)
+    const view = dataViews.get(this)
+    
+    // Use DataView for efficient reading without creating buffer slices
+    let value
+    switch (variable.jsBufferMethod) {
+      case 'readFloatLE':
+        value = view.getFloat32(header.offset, true)
+        break
+      case 'readDoubleLE':
+        value = view.getFloat64(header.offset, true)
+        break
+      case 'readInt32LE':
+        value = view.getInt32(header.offset, true)
+        break
+      case 'readUInt32LE':
+        value = view.getUint32(header.offset, true)
+        break
+      case 'readInt16LE':
+        value = view.getInt16(header.offset, true)
+        break
+      case 'readUInt16LE':
+        value = view.getUint16(header.offset, true)
+        break
+      case 'readInt8':
+        value = view.getInt8(header.offset)
+        break
+      case 'readUInt8':
+        value = view.getUint8(header.offset)
+        break
+      default:
+        // Fallback to original method if unknown type
+        const valueBuffer = this._buff.slice(header.offset, header.offset + variable.size)
+        value = valueBuffer[variable.jsBufferMethod]()
+    }
 
     return {
       name: header.name,
       description: header.description,
-      value: valueBuffer[variable.jsBufferMethod](),
+      value: value,
       unit: header.unit
     }
   }
 
   toJSON () {
-    const getParam = x => this.getParam(x)
-    const getName = R.prop('name')
-    const valueFromHeader = R.compose(R.pick(['value', 'unit']), getParam, getName)
-
-    return variableHeaders.get(this)
-      .reduce((accum, header) => R.assoc(getName(header), valueFromHeader(header), accum), {})
+    const headers = variableHeaders.get(this)
+    const result = {}
+    
+    for (const header of headers) {
+      const param = this.getParam(header.name)
+      if (param) {
+        result[header.name] = {
+          value: param.value,
+          unit: param.unit
+        }
+      }
+    }
+    
+    return result
   }
 }


### PR DESCRIPTION
Firstly I've fixed getting all the telemetry samples from the ibt file. Before it was an iterator which used a readsync on the buffer file for each iteration which caused a huge blockage on the node i/o pipeline and essentially froze the TT app.

Secondly I've fixed the get telemetry sample by adding some efficiencies, we now the use the toJSON function which was taking 10-20ms per packet which was way too slow, it now takes 1-2ms. Added some cached parameter lookups and got claude code to do some other optimisations